### PR TITLE
Redundant link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ All your data is encrypted before it leaves your computer with a private key you
 
 BitDust is written in Python using pure Twisted framework and published under GNU AGPLv3.
 
-http://bitdust.io
-
 
 
 ## Install


### PR DESCRIPTION
Idk, remove it maybe. Or just remove the one right at the top of the `README.md` and use the one I removed in this commit rather.
